### PR TITLE
[FEATURE] - Exclusão logica para incidents

### DIFF
--- a/src/main/java/br/com/thehero/domain/model/Incidents.java
+++ b/src/main/java/br/com/thehero/domain/model/Incidents.java
@@ -1,10 +1,11 @@
 package br.com.thehero.domain.model;
 
 import java.util.UUID;
-
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
@@ -19,82 +20,103 @@ import javax.persistence.Table;
 @Table(name = "incidents")
 public class Incidents extends BaseEntity {
 
-	private static final long serialVersionUID = -7504356832234307582L;
+  private static final long serialVersionUID = -7504356832234307582L;
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.AUTO)
-	private UUID uuid;
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  private UUID uuid;
 
-	@Column
-	private String title;
+  @Column
+  private String title;
 
-	@Column
-	private String description;
+  @Column
+  private String description;
 
-	@Column
-	private String value;
+  @Column
+  private String value;
 
-	@ManyToOne(fetch = FetchType.EAGER)
-	@JoinColumn(name = "organization_uuid", referencedColumnName = "uuid", foreignKey = @ForeignKey(name = "uuid"))
-	private Organization organization;
+  @ManyToOne(fetch = FetchType.EAGER)
+  @JoinColumn(name = "organization_uuid", referencedColumnName = "uuid",
+      foreignKey = @ForeignKey(name = "uuid"))
+  private Organization organization;
 
-	@OneToOne(fetch = FetchType.EAGER, cascade = CascadeType.REMOVE)
-	@JoinColumn(name = "files_uuid", referencedColumnName = "uuid", foreignKey = @ForeignKey(name = "uuid"))
-	private Files files;
+  @OneToOne(fetch = FetchType.EAGER, cascade = CascadeType.REMOVE)
+  @JoinColumn(name = "files_uuid", referencedColumnName = "uuid",
+      foreignKey = @ForeignKey(name = "uuid"))
+  private Files files;
 
-	@SuppressWarnings("unused")
-	private Incidents() {
-	}
+  @Enumerated(EnumType.STRING)
+  private Status status;
 
-	public Incidents(String title, String description, String value, Organization organization) {
-		this.title = title;
-		this.description = description;
-		this.value = value;
-		this.organization = organization;
-	}
+  @SuppressWarnings("unused")
+  private Incidents() {}
 
-	public String getTitle() {
-		return title;
-	}
+  public enum Status {
+    AVAILABLE, NOT_AVAILABLE;
+  }
 
-	public Files getFiles() {
-		return files;
-	}
+  public Incidents(String title, String description, String value, Organization organization) {
+    this.title = title;
+    this.description = description;
+    this.value = value;
+    this.organization = organization;
+    this.status = Status.AVAILABLE;
+  }
 
-	public void setFiles(Files files) {
-		this.files = files;
-	}
+  public boolean isAvailable() {
+    return this.status.equals(Status.AVAILABLE);
+  }
 
-	public void setTitle(String title) {
-		this.title = title;
-	}
+  public boolean isNotAvailable() {
+    return this.status.equals(Status.NOT_AVAILABLE);
+  }
 
-	public String getDescription() {
-		return description;
-	}
+  public void setStatus(Status status) {
+    this.status = status;
+  }
 
-	public void setDescription(String description) {
-		this.description = description;
-	}
+  public String getTitle() {
+    return title;
+  }
 
-	public String getValue() {
-		return value;
-	}
+  public Files getFiles() {
+    return files;
+  }
 
-	public void setValue(String value) {
-		this.value = value;
-	}
+  public void setFiles(Files files) {
+    this.files = files;
+  }
 
-	public Organization getOrganization() {
-		return organization;
-	}
+  public void setTitle(String title) {
+    this.title = title;
+  }
 
-	public void setOrganization(Organization organization) {
-		this.organization = organization;
-	}
+  public String getDescription() {
+    return description;
+  }
 
-	public UUID getUuid() {
-		return uuid;
-	}
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(String value) {
+    this.value = value;
+  }
+
+  public Organization getOrganization() {
+    return organization;
+  }
+
+  public void setOrganization(Organization organization) {
+    this.organization = organization;
+  }
+
+  public UUID getUuid() {
+    return uuid;
+  }
 
 }

--- a/src/main/java/br/com/thehero/domain/repository/IncidentsRepository.java
+++ b/src/main/java/br/com/thehero/domain/repository/IncidentsRepository.java
@@ -2,12 +2,16 @@ package br.com.thehero.domain.repository;
 
 import java.util.List;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import br.com.thehero.domain.model.Incidents;
+import br.com.thehero.domain.model.Incidents.Status;
 import br.com.thehero.domain.model.Organization;
 
 public interface IncidentsRepository extends JpaRepository<Incidents, UUID> {
 
   List<Incidents> findByOrganization(Organization organization);
 
+  Page<Incidents> findByStatus(Status status, Pageable pageable);
 }

--- a/src/main/java/br/com/thehero/service/incidents/impl/IncidentsServiceImpl.java
+++ b/src/main/java/br/com/thehero/service/incidents/impl/IncidentsServiceImpl.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import br.com.thehero.domain.model.Incidents;
+import br.com.thehero.domain.model.Incidents.Status;
 import br.com.thehero.domain.model.Organization;
 import br.com.thehero.domain.repository.FilesRepository;
 import br.com.thehero.domain.repository.IncidentsRepository;
@@ -18,57 +19,57 @@ import javassist.NotFoundException;
 @Service
 public class IncidentsServiceImpl implements IncidentsService {
 
-	IncidentsRepository incidentsRepository;
-	OrganizationRepository organizationRepository;
-	FilesRepository filesRepository;
+  IncidentsRepository incidentsRepository;
+  OrganizationRepository organizationRepository;
+  FilesRepository filesRepository;
 
-	public IncidentsServiceImpl(IncidentsRepository incidentsRepository, OrganizationRepository organizationRepository,
-			FilesRepository filesRepository) {
-		this.incidentsRepository = incidentsRepository;
-		this.organizationRepository = organizationRepository;
-		this.filesRepository = filesRepository;
-	}
+  public IncidentsServiceImpl(IncidentsRepository incidentsRepository,
+      OrganizationRepository organizationRepository, FilesRepository filesRepository) {
+    this.incidentsRepository = incidentsRepository;
+    this.organizationRepository = organizationRepository;
+    this.filesRepository = filesRepository;
+  }
 
-	public Incidents create(IncidentsDTO dto, String cnpjOrganization) {
-		Optional<Organization> optionaOrganization = organizationRepository.findByCnpj(cnpjOrganization);
-		if (optionaOrganization.isPresent()) {
-			Organization organization = optionaOrganization.get();
-			Incidents incidents = IncidentsConvert.convertDataTransferObjetToEntity(dto, organization);
+  public Incidents create(IncidentsDTO dto, String cnpjOrganization) {
+    Optional<Organization> optionaOrganization =
+        organizationRepository.findByCnpj(cnpjOrganization);
+    if (optionaOrganization.isPresent()) {
+      Organization organization = optionaOrganization.get();
+      Incidents incidents = IncidentsConvert.convertDataTransferObjetToEntity(dto, organization);
 
-			return incidentsRepository.saveAndFlush(incidents);
+      return incidentsRepository.saveAndFlush(incidents);
 
-		} else {
-			throw new RuntimeException("Não existe uma organização com o CNPJ informado.");
-		}
-	}
+    } else {
+      throw new RuntimeException("Não existe uma organização com o CNPJ informado.");
+    }
+  }
 
-	public Page<IncidentsDTO> findAll(Pageable pageable) {
-		return incidentsRepository.findAll(pageable)
-				.map(incident -> IncidentsConvert.convertEntityToDataTransferObject(incident));
+  public Page<IncidentsDTO> findAll(Pageable pageable) {
+    return incidentsRepository.findByStatus(Status.AVAILABLE, pageable)
+        .map(incident -> IncidentsConvert.convertEntityToDataTransferObject(incident));
+  }
 
-	}
+  public void delete(String incidentId, String cnpjOrganization) {
+    incidentsRepository.findById(UUID.fromString(incidentId)).ifPresent(incident -> {
+      if (incident.getOrganization().getCnpj().equals(cnpjOrganization)) {
+        incident.setStatus(Status.NOT_AVAILABLE);
+        incidentsRepository.save(incident);
+      } else {
+        throw new IllegalAccessError("Não autorizado!");
+      }
+    });
+  }
 
-	public void delete(String incidentId, String cnpjOrganization) {
+  public IncidentsDTO findById(String incidentsId) throws NotFoundException {
+    Optional<Incidents> incidentOptional =
+        incidentsRepository.findById(UUID.fromString(incidentsId));
 
-		incidentsRepository.findById(UUID.fromString(incidentId)).ifPresent(incident -> {
-			if (incident.getOrganization().getCnpj().equals(cnpjOrganization)) {
-				filesRepository.delete(incident.getFiles());
-				incidentsRepository.delete(incident);
-			} else {
-				throw new IllegalAccessError("Não autorizado!");
-			}
-		});
-	}
-
-	public IncidentsDTO findById(String incidentsId) throws NotFoundException {
-		Optional<Incidents> incidentOptional = incidentsRepository.findById(UUID.fromString(incidentsId));
-
-		if (incidentOptional.isPresent()) {
-			Incidents incidents = incidentOptional.get();
-			return IncidentsConvert.convertEntityToDataTransferObject(incidents);
-		} else {
-			throw new NotFoundException("Não existe um incidente com o ID informado");
-		}
-	}
+    if (incidentOptional.isPresent() && incidentOptional.get().isAvailable()) {
+      Incidents incidents = incidentOptional.get();
+      return IncidentsConvert.convertEntityToDataTransferObject(incidents);
+    } else {
+      throw new NotFoundException("Não existe um incidente com o ID informado");
+    }
+  }
 
 }

--- a/src/main/java/br/com/thehero/service/incidents/impl/IncidentsServiceImpl.java
+++ b/src/main/java/br/com/thehero/service/incidents/impl/IncidentsServiceImpl.java
@@ -31,10 +31,10 @@ public class IncidentsServiceImpl implements IncidentsService {
   }
 
   public Incidents create(IncidentsDTO dto, String cnpjOrganization) {
-    Optional<Organization> optionaOrganization =
+    Optional<Organization> optionalOrganization =
         organizationRepository.findByCnpj(cnpjOrganization);
-    if (optionaOrganization.isPresent()) {
-      Organization organization = optionaOrganization.get();
+    if (optionalOrganization.isPresent()) {
+      Organization organization = optionalOrganization.get();
       Incidents incidents = IncidentsConvert.convertDataTransferObjetToEntity(dto, organization);
 
       return incidentsRepository.saveAndFlush(incidents);
@@ -46,7 +46,7 @@ public class IncidentsServiceImpl implements IncidentsService {
 
   public Page<IncidentsDTO> findAll(Pageable pageable) {
     return incidentsRepository.findByStatus(Status.AVAILABLE, pageable)
-        .map(incident -> IncidentsConvert.convertEntityToDataTransferObject(incident));
+        .map(IncidentsConvert::convertEntityToDataTransferObject);
   }
 
   public void delete(String incidentId, String cnpjOrganization) {
@@ -60,9 +60,9 @@ public class IncidentsServiceImpl implements IncidentsService {
     });
   }
 
-  public IncidentsDTO findById(String incidentsId) throws NotFoundException {
+  public IncidentsDTO findById(String incidentId) throws NotFoundException {
     Optional<Incidents> incidentOptional =
-        incidentsRepository.findById(UUID.fromString(incidentsId));
+        incidentsRepository.findById(UUID.fromString(incidentId));
 
     if (incidentOptional.isPresent() && incidentOptional.get().isAvailable()) {
       Incidents incidents = incidentOptional.get();


### PR DESCRIPTION
### Motivação:
Os incidentes são excluídos de forma física, ou seja, removemos do banco de dados e estamos perdendo essas informações.

### Solução:
Implementar uma exclusão lógica para os incidentes.

### Tarefas realizadas:

- [x] Impl método `findByStatus(Status, Pageable);`
- [x] Modificando `findAll()` para buscar `incidents` `available` por padrão.
- [x] Modificando construtor da entidade `incidents` para criar o mesmo com o status `available` por padrão.
- [x] Modificando `delete` para que apenas atualize o status do `incident` para `not_available`.
- [x] Modificando `findById` para checar se o status do `incident` requerido é `available` .