### PR TITLE
[FIX] -  Correction in compiler test

### DIFF
--- a/.ci/script.sh
+++ b/.ci/script.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
  export MAVEN_OPTS="-Xmx1G -Xms128m"
- mvn test test 
+ mvn test -Ptest 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,5 @@ before_install:
   - psql -c 'create database "bethehero";' -U postgres
 
 script:
-  - mvn clean install
+  - chmod +x ./.ci/script.sh 
+  - ./.ci/script.sh


### PR DESCRIPTION
## Motivação:
- O `travis.yam` estava executando `mvn clean install` ao invés de chamar o `script.sh` .
- `script.sh` não estava com o profile de `test` setado.