### PR TITLE
[EH] - Implementar profiles no pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,4 +107,28 @@
 		</plugins>
 	</build>
 
+	<profiles>
+		<profile>
+			<id>dev</id>
+			<properties>
+				<activatedProperties>dev</activatedProperties>
+			</properties>
+		</profile>
+		<profile>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+			<id>test</id>
+			<properties>
+				<activatedProperties>test</activatedProperties>
+			</properties>
+		</profile>
+		<profile>
+			<id>prod</id>
+			<properties>
+				<activatedProperties>prod</activatedProperties>
+			</properties>
+		</profile>
+	</profiles>
+
 </project>


### PR DESCRIPTION
##  Motivação:

- Importante a gente ter profiles para ambientes `[test, dev e prod]` 