### PR TITLE
[EH] - Add file codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+codecov:
+  token: "92ab5c75-9ee3-4ed2-ba5a-e3438ab9ee4a"
+  
+  ignore:
+  - "src/main/java/br/br/com/thehero/config/*"
+  - "src/main/java/br/br/com/thehero/domain/*"
+  - "src/main/java/br/br/com/thehero/dto/*"
+  - "src/main/java/br/br/com/thehero/exception/*"
+  - "src/main/java/br/br/com/thehero/login/config/*"
+  - "src/main/java/br/br/com/thehero/login/model/*"
+  - "src/main/java/br/br/com/thehero/login/repository/*"
+  - "src/main/java/br/br/com/thehero/login/request/*"
+  - "src/main/java/br/br/com/thehero/login/response/*"
+  - "src/main/java/br/br/com/thehero/logout/request/*"


### PR DESCRIPTION
### Motivação
`Codecov` está verificando se algumas classes estão cobertas por testes, mas obviamente algumas classes como por exemplo a classe `br/com/thehero/logout/request/Token.java` não deveria estar mapeada como "não testada" assim como alguns "getters e setters". O intuito disso tudo é obter uma precisão mais sólida de quanto o projeto está coberto por testes.

### O que foi feito
Segundo a [documentação](https://docs.codecov.io/docs/codecov-yaml) se passarmos alguns diretórios/arquivos no parâmetro `ignore` ele ignora e então teremos uma % mais precisa da cobertura de testes do projeto. 

### Observação:
Seria muito interessante se todos realizassem um review com bastante cuidado, pois é a primeira vez que faço essa validação. Talvez tenha deixado escapar algum detalhe.