### PR TITLE
[TEST] - Criar teste para o ProfileServiceImpl

### DIFF
--- a/src/main/java/br/com/thehero/dto/IncidentsDTOList.java
+++ b/src/main/java/br/com/thehero/dto/IncidentsDTOList.java
@@ -1,22 +1,13 @@
 package br.com.thehero.dto;
 
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class IncidentsDTOList {
-
   private List<IncidentsDTO> incidents;
-
-  public IncidentsDTOList(List<IncidentsDTO> incidents) {
-    this.incidents = incidents;
-  }
-
-  public IncidentsDTOList() {}
-
-  public List<IncidentsDTO> getIncidents() {
-    return incidents;
-  }
-
-  public void setIncidents(List<IncidentsDTO> incidents) {
-    this.incidents = incidents;
-  }
 }

--- a/src/main/java/br/com/thehero/service/profile/impl/ProfileServiceImpl.java
+++ b/src/main/java/br/com/thehero/service/profile/impl/ProfileServiceImpl.java
@@ -15,22 +15,17 @@ import java.util.stream.Collectors;
 
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
 @Service
-public class ProfileServiceImpl implements ProfileService {
+class ProfileServiceImpl implements ProfileService {
+  static final String MESSAGE_ERROR = "Não existe uma organização com o CNPJ [%s] informado.";
 
-  OrganizationRepository organizationRepository;
-  IncidentsRepository incidentsRepository;
+  private OrganizationRepository organizationRepository;
+  private IncidentsRepository incidentsRepository;
 
   public IncidentsDTOList findIncidentsByOrganization(String cnpj) throws NotFoundException {
-    Organization organization =
-        this.organizationRepository
-            .findByCnpj(cnpj)
-            .orElseThrow(
-                () ->
-                    new NotFoundException(
-                        "Não existe uma organização com o CNPJ [" + cnpj + "] informado."));
-    return new IncidentsDTOList(
-        this.incidentsRepository.findByOrganization(organization).stream()
-            .map(IncidentsConvert::convertEntityToDataTransferObject)
-            .collect(Collectors.toList()));
+    Organization organization = this.organizationRepository.findByCnpj(cnpj)
+        .orElseThrow(() -> new NotFoundException(String.format(MESSAGE_ERROR, cnpj)));
+    
+    return new IncidentsDTOList(this.incidentsRepository.findByOrganization(organization).stream()
+        .map(IncidentsConvert::convertEntityToDataTransferObject).collect(Collectors.toList()));
   }
 }

--- a/src/test/java/br/com/thehero/providers/IncidentsEntityProviderTest.java
+++ b/src/test/java/br/com/thehero/providers/IncidentsEntityProviderTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import br.com.thehero.IncidentsConstantsTest;
 import br.com.thehero.OrganizationConstantsTest;
+import br.com.thehero.domain.model.Files;
 import br.com.thehero.domain.model.Incidents;
 import br.com.thehero.domain.model.Incidents.Status;
 import br.com.thehero.domain.model.Organization;
@@ -16,9 +17,12 @@ public class IncidentsEntityProviderTest
 
   @Override
   public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+    byte[] data = new byte[2];
+    Files files = Files.newBuilder().type("PNG").data(data).build();
     return Stream.of(
             Incidents.newBuilder()
                 .description(DESCRIPTION)
+                .files(files)
                 .organization(
                     Organization.newBuilder()
                         .uuid(UUID.randomUUID())

--- a/src/test/java/br/com/thehero/service/profile/impl/TestProfileServiceImpl.java
+++ b/src/test/java/br/com/thehero/service/profile/impl/TestProfileServiceImpl.java
@@ -1,0 +1,78 @@
+package br.com.thehero.service.profile.impl;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.mockito.BDDMockito;
+import org.mockito.Mockito;
+import br.com.thehero.OrganizationConstantsTest;
+import br.com.thehero.domain.model.Incidents;
+import br.com.thehero.domain.model.Organization;
+import br.com.thehero.domain.repository.IncidentsRepository;
+import br.com.thehero.domain.repository.OrganizationRepository;
+import br.com.thehero.dto.IncidentsDTOList;
+import br.com.thehero.providers.IncidentsEntityProviderTest;
+import br.com.thehero.service.profile.ProfileService;
+import javassist.NotFoundException;
+
+class TestProfileServiceImpl implements OrganizationConstantsTest {
+
+  private ProfileService service;
+  private OrganizationRepository organizationRepository;
+  private IncidentsRepository incidentsRepository;
+
+  @BeforeEach
+  void setUp() {
+    this.organizationRepository = mock(OrganizationRepository.class);
+    this.incidentsRepository = mock(IncidentsRepository.class);
+    this.service = new ProfileServiceImpl(organizationRepository, incidentsRepository);
+  }
+
+  @ParameterizedTest
+  @ArgumentsSource(IncidentsEntityProviderTest.class)
+  void shouldFindIncidentsByOrganizationWithSuccess(Incidents incidents) throws NotFoundException {
+    // given
+    List<Incidents> incidentsList = new ArrayList<>();
+    incidentsList.add(incidents);
+    Organization organization = Organization.newBuilder().name(NAME).city(CITY).cnpj(CNPJ)
+        .email(EMAIL_ONG).uf(UF).whatsapp(WHATSAPP).build();
+    // when
+    BDDMockito.when(this.organizationRepository.findByCnpj(organization.getCnpj()))
+        .thenReturn(Optional.of(organization));
+    BDDMockito.when(this.incidentsRepository.findByOrganization(organization))
+        .thenReturn(incidentsList);
+
+    // then
+    IncidentsDTOList incidentsDTOList =
+        this.service.findIncidentsByOrganization(organization.getCnpj());
+
+    verify(this.organizationRepository, times(1)).findByCnpj(Mockito.anyString());
+    verify(this.incidentsRepository, times(1)).findByOrganization(Mockito.any());
+
+    assertEquals(1, incidentsDTOList.getIncidents().size());
+  }
+
+  @Test
+  void shouldFindIncidentsByOrganizationWithError() {
+    // when
+    BDDMockito.when(this.organizationRepository.findByCnpj(CNPJ)).thenReturn(Optional.empty());
+
+    Exception exception = assertThrows(Exception.class, () -> {
+      this.service.findIncidentsByOrganization(CNPJ);
+    });
+
+    assertTrue(exception instanceof NotFoundException);
+    assertEquals(String.format(ProfileServiceImpl.MESSAGE_ERROR, CNPJ), exception.getMessage());
+  }
+
+}


### PR DESCRIPTION
- [x] Adicionei o atributo file no Provider de teste do `Incident`
- [x] Criei um atributo no `ProfileServiceImpl` para a mensagem de erro, assim pude utilizar a mesma mensagem no teste para garantir que a mensagem de erro é a mesma que estamos esperando.
- [x] Criei 2 testes, um para o cenário onde a busca por `incidents` ocorre com sucesso  e outro teste para o cenário de erro quando não encontrarmos uma organização com o `CNPJ` informado.